### PR TITLE
Removed backslash in namespace assumption in EventServiceProvider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ To customize this experience, create an Event inside your applications `EventSer
 ```php
     public function boot()
     {
-          // assuming: use ZiffMedia\Laravel\Onelogin\Events\OneloginLoginEvent;
+          // assuming: use ZiffMedia\LaravelOnelogin\Events\OneloginLoginEvent;
 
           Event::listen(OneloginLoginEvent::class, function (OneloginLoginEvent $event) {
               $user = User::firstOrNew(['email' => $event->userAttributes['User.email'][0]]);


### PR DESCRIPTION
This fixes an extra slash in the comment - I only noticed it as I cut and past the namespace and realised it wasn't correct.