### PR TITLE
Added config field for x509certNew for when roll over is near

### DIFF
--- a/src/OneloginServiceProvider.php
+++ b/src/OneloginServiceProvider.php
@@ -94,6 +94,7 @@ class OneloginServiceProvider extends ServiceProvider
                     'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
                     'x509cert' => '',
                     'privateKey' => '',
+                    'x509certNew' => '',
                 ],
                 'idp' => [
                     'entityId' => config('onelogin.issuer_url'),


### PR DESCRIPTION
This adds x509certNew field for use when a new certificate is going to be used, to match onelogin/php-saml config